### PR TITLE
Compute palette ramp once in scale_plot_base

### DIFF
--- a/R/scale_plot_base.R
+++ b/R/scale_plot_base.R
@@ -45,6 +45,8 @@ scale_plot_base <- function(
     pal_vector <- rev(pal_vector)
   }
 
+  crp <- grDevices::colorRampPalette(pal_vector)
+
   # Construct palette function
   pal_fn <- function(n) {
     if (select_distinct && discrete) {
@@ -53,7 +55,7 @@ scale_plot_base <- function(
     if (n <= length(pal_vector)) {
       pal_vector[1:n]
     } else {
-      grDevices::colorRampPalette(pal_vector)(n)
+      crp(n)
     }
   }
 
@@ -68,12 +70,12 @@ scale_plot_base <- function(
   } else {
     if (type == "fill") {
       ggplot2::scale_fill_gradientn(
-        colours = grDevices::colorRampPalette(pal_vector)(256),
+        colours = crp(256),
         ...
       )
     } else {
       ggplot2::scale_colour_gradientn(
-        colours = grDevices::colorRampPalette(pal_vector)(256),
+        colours = crp(256),
         ...
       )
     }


### PR DESCRIPTION
## Summary
- Avoid repeated `colorRampPalette()` calls by creating `crp` once in `scale_plot_base()`
- Use cached palette for both discrete and continuous scales

## Testing
- `R -q -e "if (dir.exists('tests')) testthat::test_dir('tests') else cat('No tests found\n')"`
- `R -q -f /tmp/test_pal.R`

------
https://chatgpt.com/codex/tasks/task_e_6890c53bf5308325908a205a4a97d9b0